### PR TITLE
EODHP-1266 label main assets consistently in commercial data outputs

### DIFF
--- a/airbus/common/stac_utils.py
+++ b/airbus/common/stac_utils.py
@@ -227,6 +227,7 @@ def ingest_stac_item(
     # Close the Pulsar client
     pulsar_client.close()
 
+
 def get_asset_details(file_path: str, collection_id: str) -> tuple[str, str]:
     """
     Returns a tuple (name, description) if a match is found, otherwise (file_base_name, "").
@@ -234,49 +235,145 @@ def get_asset_details(file_path: str, collection_id: str) -> tuple[str, str]:
     regex_patterns = {
         "airbus_sar_data": [
             # Imagery
-            (r"imagedata\/[^\\:?\"<>|]+\.(cos|tif|tiff)$", "primaryAsset", "GeoTIFF image file"),
-            (r"imagedata\/[^\\:?\"<>|]+\.(cos)$", "primaryAsset", "COSAR binary image file"),
-            (r"preview\/map_plot\.png$", "mapPlot", "A coarse geographical map showing the footprint of the scene as a low-resolution image"),
+            (
+                r"imagedata\/[^\\:?\"<>|]+\.(cos|tif|tiff)$",
+                "primaryAsset",
+                "GeoTIFF image file",
+            ),
+            (
+                r"imagedata\/[^\\:?\"<>|]+\.(cos)$",
+                "primaryAsset",
+                "COSAR binary image file",
+            ),
+            (
+                r"preview\/map_plot\.png$",
+                "mapPlot",
+                "A coarse geographical map showing the footprint of the scene as a low-resolution image",
+            ),
             (r"preview\/browse\.tif$", "thumbnail", "A thumbnail image of the scene"),
-            (r"preview\/composite_ql\.tif$", "quicklook", "A composite quicklook image composed of all layers"),
-            (r"preview\/[^\\:?\"<>|]+\.tif$", "quicklookLayer", "Individual quicklook layer"),
+            (
+                r"preview\/composite_ql\.tif$",
+                "quicklook",
+                "A composite quicklook image composed of all layers",
+            ),
+            (
+                r"preview\/[^\\:?\"<>|]+\.tif$",
+                "quicklookLayer",
+                "Individual quicklook layer",
+            ),
         ],
         "optical": [
             # Imagery
-            (r"\/img_[^\\:?\"<>|]+_r\d+c\d+\.(tif|tiff|jp2)$", "primaryAsset", "Full resolution image file, possibly tiled. Row (R) and Col (C) image tile indexes"),
-            (r"\/img_[^\\:?\"<>|]+_r\d+c\d+\.(tfw|j2w)$", "georeference", "Simple assembling/georeferencing file, possibly tiled. Row (R) and Col (C) image tile indexes"),
+            (
+                r"\/img_[^\\:?\"<>|]+_r\d+c\d+\.(tif|tiff|jp2)$",
+                "primaryAsset",
+                "Full resolution image file, possibly tiled. Row (R) and Col (C) image tile indexes",
+            ),
+            (
+                r"\/img_[^\\:?\"<>|]+_r\d+c\d+\.(tfw|j2w)$",
+                "georeference",
+                "Simple assembling/georeferencing file, possibly tiled. Row (R) and Col (C) image tile indexes",
+            ),
             (r"\/preview_[^\\:?\"<>|]+\.jpg$", "quicklook", "Quicklook raster file"),
             (r"\/preview_[^\\:?\"<>|]+\.kmz$", "quicklookKMZ", "Quicklook KMZ file"),
             (r"\/icon_[^\\:?\"<>|]+\.jpg$", "thumbnail", "Thumbnail raster file"),
             # Metadata
             (r"\/dim_[^\\:?\"<>|]+\.xml$", "DIMAP", "Main product metadata file"),
             (r"\/iso_[^\\:?\"<>|]+\.xml$", "ISO", "ISO 19115/19139 metadata file"),
-            (r"\/lut_[^\\:?\"<>|]+\.xml$", "LUT", "DIMAP, LUT colour curves metadata file"),
+            (
+                r"\/lut_[^\\:?\"<>|]+\.xml$",
+                "LUT",
+                "DIMAP, LUT colour curves metadata file",
+            ),
             (r"\/rpc_[^\\:?\"<>|]+\.xml$", "RPC", "DIMAP, RPC metadata file"),
-            (r"\/ground_[^\\:?\"<>|]+\.xml$", "GROUND", "DIMAP, Ground Source metadata file"),
-            (r"\/height_[^\\:?\"<>|]+\.xml$", "HEIGHT", "DIMAP, Height Source metadata file"),
-            (r"\/processing_[^\\:?\"<>|]+\.xml$", "PROCESSING", "DIMAP, Processing lineage file"),
-            (r"\/gipp_[^\\:?\"<>|]+\.xml$", "GIPP", "Ground Image Processing Parameters file"),
-            (r"\/strip_[^\\:?\"<>|]+\.xml$", "STRIP", "DIMAP, Data Strip Source metadata file"),
+            (
+                r"\/ground_[^\\:?\"<>|]+\.xml$",
+                "GROUND",
+                "DIMAP, Ground Source metadata file",
+            ),
+            (
+                r"\/height_[^\\:?\"<>|]+\.xml$",
+                "HEIGHT",
+                "DIMAP, Height Source metadata file",
+            ),
+            (
+                r"\/processing_[^\\:?\"<>|]+\.xml$",
+                "PROCESSING",
+                "DIMAP, Processing lineage file",
+            ),
+            (
+                r"\/gipp_[^\\:?\"<>|]+\.xml$",
+                "GIPP",
+                "Ground Image Processing Parameters file",
+            ),
+            (
+                r"\/strip_[^\\:?\"<>|]+\.xml$",
+                "STRIP",
+                "DIMAP, Data Strip Source metadata file",
+            ),
             # Masks
-            (r"\/masks\/roi_[^\\:?\"<>|]+\.gml$", "ROIMask", "GML, Region of interest vector mask"),
+            (
+                r"\/masks\/roi_[^\\:?\"<>|]+\.gml$",
+                "ROIMask",
+                "GML, Region of interest vector mask",
+            ),
             (r"\/masks\/cld_[^\\:?\"<>|]+\.gml$", "CLDMask", "GML, Cloud vector mask"),
-            (r"\/masks\/qte_[^\\:?\"<>|]+\.gml$", "QTEMask", "GML, Synthetic technical quality vector mask"),
+            (
+                r"\/masks\/qte_[^\\:?\"<>|]+\.gml$",
+                "QTEMask",
+                "GML, Synthetic technical quality vector mask",
+            ),
             (r"\/masks\/snw_[^\\:?\"<>|]+\.gml$", "SNWMask", "GML, Snow vector mask"),
-            (r"\/masks\/det_[^\\:?\"<>|]+\.gml$", "DETMask", "GML, Out of order detectors vector mask"),
-            (r"\/masks\/vis_[^\\:?\"<>|]+\.gml$", "VISMask", "GML, Hidden area vector mask"),
-            (r"\/masks\/slt_[^\\:?\"<>|]+\.gml$", "SLTMask", "GML, Straylight vector mask"),
-            (r"\/masks\/dtm_[^\\:?\"<>|]+\.gml$", "DTMMask", "GML, DTM quality vector mask"),
-            (r"\/masks\/wat_[^\\:?\"<>|]+\.gml$", "WATMask", "GML, Water areas vector mask"),
-            (r"\/masks\/cut_[^\\:?\"<>|]+\.shp$", "CUTMask", "Shapefile, cutline vector mask"),
-            (r"\/masks\/ppm_[^\\:?\"<>|]+\.$", "PPMMask", "Planimetric accuracy Performance assessment Mask, raster"),
+            (
+                r"\/masks\/det_[^\\:?\"<>|]+\.gml$",
+                "DETMask",
+                "GML, Out of order detectors vector mask",
+            ),
+            (
+                r"\/masks\/vis_[^\\:?\"<>|]+\.gml$",
+                "VISMask",
+                "GML, Hidden area vector mask",
+            ),
+            (
+                r"\/masks\/slt_[^\\:?\"<>|]+\.gml$",
+                "SLTMask",
+                "GML, Straylight vector mask",
+            ),
+            (
+                r"\/masks\/dtm_[^\\:?\"<>|]+\.gml$",
+                "DTMMask",
+                "GML, DTM quality vector mask",
+            ),
+            (
+                r"\/masks\/wat_[^\\:?\"<>|]+\.gml$",
+                "WATMask",
+                "GML, Water areas vector mask",
+            ),
+            (
+                r"\/masks\/cut_[^\\:?\"<>|]+\.shp$",
+                "CUTMask",
+                "Shapefile, cutline vector mask",
+            ),
+            (
+                r"\/masks\/ppm_[^\\:?\"<>|]+\.$",
+                "PPMMask",
+                "Planimetric accuracy Performance assessment Mask, raster",
+            ),
             # Miscellaneous
-            (r"\/vol_[^\\:?\"<>|]+\.xml$", "indexVolume", "Index volume file of products contained in the delivery"),
+            (
+                r"\/vol_[^\\:?\"<>|]+\.xml$",
+                "indexVolume",
+                "Index volume file of products contained in the delivery",
+            ),
             (r"\/delivery\.pdf$", "delivery", "Delivery note"),
             (r"\/license\.pdf$", "license", "License file"),
             (r"\/index\.htm$", "index", "Index file"),
             (r"logo\.jpg$", "logo", "Logo file"),
-            (r"style\.xsl$", "styleSheet", "Short metadata content for discovering purpose"),
+            (
+                r"style\.xsl$",
+                "styleSheet",
+                "Short metadata content for discovering purpose",
+            ),
         ],
     }
 

--- a/airbus/common/stac_utils.py
+++ b/airbus/common/stac_utils.py
@@ -4,6 +4,7 @@ import mimetypes
 import os
 from datetime import datetime, timezone
 from enum import Enum
+import re
 from typing import List, Union
 
 import boto3
@@ -226,6 +227,70 @@ def ingest_stac_item(
     # Close the Pulsar client
     pulsar_client.close()
 
+def get_asset_details(file_path: str, collection_id: str) -> tuple[str, str]:
+    """
+    Returns a tuple (name, description) if a match is found, otherwise (file_base_name, "").
+    """
+    regex_patterns = {
+        "airbus_sar_data": [
+            # Imagery
+            (r"imagedata\/[^\\:?\"<>|]+\.(cos|tif|tiff)$", "primaryAsset", "GeoTIFF image file"),
+            (r"imagedata\/[^\\:?\"<>|]+\.(cos)$", "primaryAsset", "COSAR binary image file"),
+            (r"preview\/map_plot\.png$", "mapPlot", "A coarse geographical map showing the footprint of the scene as a low-resolution image"),
+            (r"preview\/browse\.tif$", "thumbnail", "A thumbnail image of the scene"),
+            (r"preview\/composite_ql\.tif$", "quicklook", "A composite quicklook image composed of all layers"),
+            (r"preview\/[^\\:?\"<>|]+\.tif$", "quicklookLayer", "Individual quicklook layer"),
+        ],
+        "optical": [
+            # Imagery
+            (r"\/img_[^\\:?\"<>|]+_r\d+c\d+\.(tif|tiff|jp2)$", "primaryAsset", "Full resolution image file, possibly tiled. Row (R) and Col (C) image tile indexes"),
+            (r"\/img_[^\\:?\"<>|]+_r\d+c\d+\.(tfw|j2w)$", "georeference", "Simple assembling/georeferencing file, possibly tiled. Row (R) and Col (C) image tile indexes"),
+            (r"\/preview_[^\\:?\"<>|]+\.jpg$", "quicklook", "Quicklook raster file"),
+            (r"\/preview_[^\\:?\"<>|]+\.kmz$", "quicklookKMZ", "Quicklook KMZ file"),
+            (r"\/icon_[^\\:?\"<>|]+\.jpg$", "thumbnail", "Thumbnail raster file"),
+            # Metadata
+            (r"\/dim_[^\\:?\"<>|]+\.xml$", "DIMAP", "Main product metadata file"),
+            (r"\/iso_[^\\:?\"<>|]+\.xml$", "ISO", "ISO 19115/19139 metadata file"),
+            (r"\/lut_[^\\:?\"<>|]+\.xml$", "LUT", "DIMAP, LUT colour curves metadata file"),
+            (r"\/rpc_[^\\:?\"<>|]+\.xml$", "RPC", "DIMAP, RPC metadata file"),
+            (r"\/ground_[^\\:?\"<>|]+\.xml$", "GROUND", "DIMAP, Ground Source metadata file"),
+            (r"\/height_[^\\:?\"<>|]+\.xml$", "HEIGHT", "DIMAP, Height Source metadata file"),
+            (r"\/processing_[^\\:?\"<>|]+\.xml$", "PROCESSING", "DIMAP, Processing lineage file"),
+            (r"\/gipp_[^\\:?\"<>|]+\.xml$", "GIPP", "Ground Image Processing Parameters file"),
+            (r"\/strip_[^\\:?\"<>|]+\.xml$", "STRIP", "DIMAP, Data Strip Source metadata file"),
+            # Masks
+            (r"\/masks\/roi_[^\\:?\"<>|]+\.gml$", "ROIMask", "GML, Region of interest vector mask"),
+            (r"\/masks\/cld_[^\\:?\"<>|]+\.gml$", "CLDMask", "GML, Cloud vector mask"),
+            (r"\/masks\/qte_[^\\:?\"<>|]+\.gml$", "QTEMask", "GML, Synthetic technical quality vector mask"),
+            (r"\/masks\/snw_[^\\:?\"<>|]+\.gml$", "SNWMask", "GML, Snow vector mask"),
+            (r"\/masks\/det_[^\\:?\"<>|]+\.gml$", "DETMask", "GML, Out of order detectors vector mask"),
+            (r"\/masks\/vis_[^\\:?\"<>|]+\.gml$", "VISMask", "GML, Hidden area vector mask"),
+            (r"\/masks\/slt_[^\\:?\"<>|]+\.gml$", "SLTMask", "GML, Straylight vector mask"),
+            (r"\/masks\/dtm_[^\\:?\"<>|]+\.gml$", "DTMMask", "GML, DTM quality vector mask"),
+            (r"\/masks\/wat_[^\\:?\"<>|]+\.gml$", "WATMask", "GML, Water areas vector mask"),
+            (r"\/masks\/cut_[^\\:?\"<>|]+\.shp$", "CUTMask", "Shapefile, cutline vector mask"),
+            (r"\/masks\/ppm_[^\\:?\"<>|]+\.$", "PPMMask", "Planimetric accuracy Performance assessment Mask, raster"),
+            # Miscellaneous
+            (r"\/vol_[^\\:?\"<>|]+\.xml$", "indexVolume", "Index volume file of products contained in the delivery"),
+            (r"\/delivery\.pdf$", "delivery", "Delivery note"),
+            (r"\/license\.pdf$", "license", "License file"),
+            (r"\/index\.htm$", "index", "Index file"),
+            (r"logo\.jpg$", "logo", "Logo file"),
+            (r"style\.xsl$", "styleSheet", "Short metadata content for discovering purpose"),
+        ],
+    }
+
+    # Select the appropriate regex list based on collection_id
+    patterns = regex_patterns.get(collection_id, regex_patterns["optical"])
+
+    # Test the file path against each regex
+    for pattern, name, description in patterns:
+        if re.search(pattern, file_path.lower()):
+            return name, description
+
+    # If no match is found, return file name and empty description
+    return os.path.basename(file_path), ""
+
 
 def update_stac_item_failure(
     stac_item: dict,
@@ -292,10 +357,26 @@ def update_stac_item_success(
 ):
     """Update the STAC item with the assets and success order status"""
     # Add all files in the directory as assets to the STAC item
-    for root, _, files in os.walk(directory):
-        for asset in files:
+    name_counter = {}
+    for root, dirs, files in os.walk(directory):
+        dirs.sort()
+        for asset in sorted(files):
             asset_path = os.path.join(root, asset)
-            asset_name = os.path.basename(asset_path)
+            asset_name, description = get_asset_details(asset_path, collection_id)
+
+            # Append row and column indexes to the asset name if they exist
+            match = re.search(r"_R\d+C\d+\.", asset_path.upper())
+            if match:
+                # Remove trailing dot originating from the extension
+                asset_name = asset_name + match.group(0)[:-1]
+
+            # Cannot have duplicate asset names
+            if asset_name in name_counter:
+                # Append an incrementing integer
+                name_counter[asset_name] += 1
+                asset_name = f"{asset_name}_{name_counter[asset_name]}"
+            else:
+                name_counter[asset_name] = 0
 
             # Determine the MIME type of the file
             mime_type, _ = mimetypes.guess_type(asset_path)
@@ -307,6 +388,8 @@ def update_stac_item_success(
                 "href": asset_path,
                 "type": mime_type,
             }
+            if description:
+                stac_item["assets"][asset_name]["title"] = description
     # Mark the order as succeeded and upload the updated STAC item
     update_stac_order_status(stac_item, order_id, OrderStatus.SUCCEEDED.value)
 

--- a/airbus/common/stac_utils.py
+++ b/airbus/common/stac_utils.py
@@ -462,10 +462,9 @@ def update_stac_item_success(
             asset_name, description = get_asset_details(asset_path, collection_id)
 
             # Append row and column indexes to the asset name if they exist
-            match = re.search(r"_R\d+C\d+\.", asset_path.upper())
+            match = re.search(r"(_R\d+C\d+)\.", asset_path.upper())
             if match:
-                # Remove trailing dot originating from the extension
-                asset_name = asset_name + match.group(0)[:-1]
+                asset_name = asset_name + match.group(1)
 
             # Cannot have duplicate asset names
             if asset_name in name_counter:

--- a/airbus/common/stac_utils.py
+++ b/airbus/common/stac_utils.py
@@ -13,6 +13,152 @@ import pulsar
 Coordinate = Union[List[float], tuple[float, float]]
 
 
+REGEX_PATTERNS = {
+    "airbus_sar_data": [
+        # Imagery
+        (
+            r"imagedata\/[^\\:?\"<>|]+\.(cos|tif|tiff)$",
+            "primaryAsset",
+            "GeoTIFF image file",
+        ),
+        (
+            r"imagedata\/[^\\:?\"<>|]+\.(cos)$",
+            "primaryAsset",
+            "COSAR binary image file",
+        ),
+        (
+            r"preview\/map_plot\.png$",
+            "mapPlot",
+            "A coarse geographical map showing the footprint of the scene as a low-resolution image",
+        ),
+        (r"preview\/browse\.tif$", "thumbnail", "A thumbnail image of the scene"),
+        (
+            r"preview\/composite_ql\.tif$",
+            "quicklook",
+            "A composite quicklook image composed of all layers",
+        ),
+        (
+            r"preview\/[^\\:?\"<>|]+\.tif$",
+            "quicklookLayer",
+            "Individual quicklook layer",
+        ),
+    ],
+    "optical": [
+        # Imagery
+        (
+            r"\/img_[^\\:?\"<>|]+_r\d+c\d+\.(tif|tiff|jp2)$",
+            "primaryAsset",
+            "Full resolution image file, possibly tiled. Row (R) and Col (C) image tile indexes",
+        ),
+        (
+            r"\/img_[^\\:?\"<>|]+_r\d+c\d+\.(tfw|j2w)$",
+            "georeference",
+            "Simple assembling/georeferencing file, possibly tiled. Row (R) and Col (C) image tile indexes",
+        ),
+        (r"\/preview_[^\\:?\"<>|]+\.jpg$", "quicklook", "Quicklook raster file"),
+        (r"\/preview_[^\\:?\"<>|]+\.kmz$", "quicklookKMZ", "Quicklook KMZ file"),
+        (r"\/icon_[^\\:?\"<>|]+\.jpg$", "thumbnail", "Thumbnail raster file"),
+        # Metadata
+        (r"\/dim_[^\\:?\"<>|]+\.xml$", "DIMAP", "Main product metadata file"),
+        (r"\/iso_[^\\:?\"<>|]+\.xml$", "ISO", "ISO 19115/19139 metadata file"),
+        (
+            r"\/lut_[^\\:?\"<>|]+\.xml$",
+            "LUT",
+            "DIMAP, LUT colour curves metadata file",
+        ),
+        (r"\/rpc_[^\\:?\"<>|]+\.xml$", "RPC", "DIMAP, RPC metadata file"),
+        (
+            r"\/ground_[^\\:?\"<>|]+\.xml$",
+            "GROUND",
+            "DIMAP, Ground Source metadata file",
+        ),
+        (
+            r"\/height_[^\\:?\"<>|]+\.xml$",
+            "HEIGHT",
+            "DIMAP, Height Source metadata file",
+        ),
+        (
+            r"\/processing_[^\\:?\"<>|]+\.xml$",
+            "PROCESSING",
+            "DIMAP, Processing lineage file",
+        ),
+        (
+            r"\/gipp_[^\\:?\"<>|]+\.xml$",
+            "GIPP",
+            "Ground Image Processing Parameters file",
+        ),
+        (
+            r"\/strip_[^\\:?\"<>|]+\.xml$",
+            "STRIP",
+            "DIMAP, Data Strip Source metadata file",
+        ),
+        # Masks
+        (
+            r"\/masks\/roi_[^\\:?\"<>|]+\.gml$",
+            "ROIMask",
+            "GML, Region of interest vector mask",
+        ),
+        (r"\/masks\/cld_[^\\:?\"<>|]+\.gml$", "CLDMask", "GML, Cloud vector mask"),
+        (
+            r"\/masks\/qte_[^\\:?\"<>|]+\.gml$",
+            "QTEMask",
+            "GML, Synthetic technical quality vector mask",
+        ),
+        (r"\/masks\/snw_[^\\:?\"<>|]+\.gml$", "SNWMask", "GML, Snow vector mask"),
+        (
+            r"\/masks\/det_[^\\:?\"<>|]+\.gml$",
+            "DETMask",
+            "GML, Out of order detectors vector mask",
+        ),
+        (
+            r"\/masks\/vis_[^\\:?\"<>|]+\.gml$",
+            "VISMask",
+            "GML, Hidden area vector mask",
+        ),
+        (
+            r"\/masks\/slt_[^\\:?\"<>|]+\.gml$",
+            "SLTMask",
+            "GML, Straylight vector mask",
+        ),
+        (
+            r"\/masks\/dtm_[^\\:?\"<>|]+\.gml$",
+            "DTMMask",
+            "GML, DTM quality vector mask",
+        ),
+        (
+            r"\/masks\/wat_[^\\:?\"<>|]+\.gml$",
+            "WATMask",
+            "GML, Water areas vector mask",
+        ),
+        (
+            r"\/masks\/cut_[^\\:?\"<>|]+\.shp$",
+            "CUTMask",
+            "Shapefile, cutline vector mask",
+        ),
+        (
+            r"\/masks\/ppm_[^\\:?\"<>|]+\.$",
+            "PPMMask",
+            "Planimetric accuracy Performance assessment Mask, raster",
+        ),
+        # Miscellaneous
+        (
+            r"\/vol_[^\\:?\"<>|]+\.xml$",
+            "indexVolume",
+            "Index volume file of products contained in the delivery",
+        ),
+        (r"\/delivery\.pdf$", "delivery", "Delivery note"),
+        (r"\/license\.pdf$", "license", "License file"),
+        (r"\/index\.htm$", "index", "Index file"),
+        (r"logo\.jpg$", "logo", "Logo file"),
+        (
+            r"style\.xsl$",
+            "styleSheet",
+            "Short metadata content for discovering purpose",
+        ),
+    ],
+}
+
+
 class OrderStatus(Enum):
     ORDERABLE = "orderable"
     ORDERED = "ordered"
@@ -232,153 +378,8 @@ def get_asset_details(file_path: str, collection_id: str) -> tuple[str, str]:
     """
     Returns a tuple (name, description) if a match is found, otherwise (file_base_name, "").
     """
-    regex_patterns = {
-        "airbus_sar_data": [
-            # Imagery
-            (
-                r"imagedata\/[^\\:?\"<>|]+\.(cos|tif|tiff)$",
-                "primaryAsset",
-                "GeoTIFF image file",
-            ),
-            (
-                r"imagedata\/[^\\:?\"<>|]+\.(cos)$",
-                "primaryAsset",
-                "COSAR binary image file",
-            ),
-            (
-                r"preview\/map_plot\.png$",
-                "mapPlot",
-                "A coarse geographical map showing the footprint of the scene as a low-resolution image",
-            ),
-            (r"preview\/browse\.tif$", "thumbnail", "A thumbnail image of the scene"),
-            (
-                r"preview\/composite_ql\.tif$",
-                "quicklook",
-                "A composite quicklook image composed of all layers",
-            ),
-            (
-                r"preview\/[^\\:?\"<>|]+\.tif$",
-                "quicklookLayer",
-                "Individual quicklook layer",
-            ),
-        ],
-        "optical": [
-            # Imagery
-            (
-                r"\/img_[^\\:?\"<>|]+_r\d+c\d+\.(tif|tiff|jp2)$",
-                "primaryAsset",
-                "Full resolution image file, possibly tiled. Row (R) and Col (C) image tile indexes",
-            ),
-            (
-                r"\/img_[^\\:?\"<>|]+_r\d+c\d+\.(tfw|j2w)$",
-                "georeference",
-                "Simple assembling/georeferencing file, possibly tiled. Row (R) and Col (C) image tile indexes",
-            ),
-            (r"\/preview_[^\\:?\"<>|]+\.jpg$", "quicklook", "Quicklook raster file"),
-            (r"\/preview_[^\\:?\"<>|]+\.kmz$", "quicklookKMZ", "Quicklook KMZ file"),
-            (r"\/icon_[^\\:?\"<>|]+\.jpg$", "thumbnail", "Thumbnail raster file"),
-            # Metadata
-            (r"\/dim_[^\\:?\"<>|]+\.xml$", "DIMAP", "Main product metadata file"),
-            (r"\/iso_[^\\:?\"<>|]+\.xml$", "ISO", "ISO 19115/19139 metadata file"),
-            (
-                r"\/lut_[^\\:?\"<>|]+\.xml$",
-                "LUT",
-                "DIMAP, LUT colour curves metadata file",
-            ),
-            (r"\/rpc_[^\\:?\"<>|]+\.xml$", "RPC", "DIMAP, RPC metadata file"),
-            (
-                r"\/ground_[^\\:?\"<>|]+\.xml$",
-                "GROUND",
-                "DIMAP, Ground Source metadata file",
-            ),
-            (
-                r"\/height_[^\\:?\"<>|]+\.xml$",
-                "HEIGHT",
-                "DIMAP, Height Source metadata file",
-            ),
-            (
-                r"\/processing_[^\\:?\"<>|]+\.xml$",
-                "PROCESSING",
-                "DIMAP, Processing lineage file",
-            ),
-            (
-                r"\/gipp_[^\\:?\"<>|]+\.xml$",
-                "GIPP",
-                "Ground Image Processing Parameters file",
-            ),
-            (
-                r"\/strip_[^\\:?\"<>|]+\.xml$",
-                "STRIP",
-                "DIMAP, Data Strip Source metadata file",
-            ),
-            # Masks
-            (
-                r"\/masks\/roi_[^\\:?\"<>|]+\.gml$",
-                "ROIMask",
-                "GML, Region of interest vector mask",
-            ),
-            (r"\/masks\/cld_[^\\:?\"<>|]+\.gml$", "CLDMask", "GML, Cloud vector mask"),
-            (
-                r"\/masks\/qte_[^\\:?\"<>|]+\.gml$",
-                "QTEMask",
-                "GML, Synthetic technical quality vector mask",
-            ),
-            (r"\/masks\/snw_[^\\:?\"<>|]+\.gml$", "SNWMask", "GML, Snow vector mask"),
-            (
-                r"\/masks\/det_[^\\:?\"<>|]+\.gml$",
-                "DETMask",
-                "GML, Out of order detectors vector mask",
-            ),
-            (
-                r"\/masks\/vis_[^\\:?\"<>|]+\.gml$",
-                "VISMask",
-                "GML, Hidden area vector mask",
-            ),
-            (
-                r"\/masks\/slt_[^\\:?\"<>|]+\.gml$",
-                "SLTMask",
-                "GML, Straylight vector mask",
-            ),
-            (
-                r"\/masks\/dtm_[^\\:?\"<>|]+\.gml$",
-                "DTMMask",
-                "GML, DTM quality vector mask",
-            ),
-            (
-                r"\/masks\/wat_[^\\:?\"<>|]+\.gml$",
-                "WATMask",
-                "GML, Water areas vector mask",
-            ),
-            (
-                r"\/masks\/cut_[^\\:?\"<>|]+\.shp$",
-                "CUTMask",
-                "Shapefile, cutline vector mask",
-            ),
-            (
-                r"\/masks\/ppm_[^\\:?\"<>|]+\.$",
-                "PPMMask",
-                "Planimetric accuracy Performance assessment Mask, raster",
-            ),
-            # Miscellaneous
-            (
-                r"\/vol_[^\\:?\"<>|]+\.xml$",
-                "indexVolume",
-                "Index volume file of products contained in the delivery",
-            ),
-            (r"\/delivery\.pdf$", "delivery", "Delivery note"),
-            (r"\/license\.pdf$", "license", "License file"),
-            (r"\/index\.htm$", "index", "Index file"),
-            (r"logo\.jpg$", "logo", "Logo file"),
-            (
-                r"style\.xsl$",
-                "styleSheet",
-                "Short metadata content for discovering purpose",
-            ),
-        ],
-    }
-
     # Select the appropriate regex list based on collection_id
-    patterns = regex_patterns.get(collection_id, regex_patterns["optical"])
+    patterns = REGEX_PATTERNS.get(collection_id, REGEX_PATTERNS["optical"])
 
     # Test the file path against each regex
     for pattern, name, description in patterns:

--- a/airbus/common/stac_utils.py
+++ b/airbus/common/stac_utils.py
@@ -2,9 +2,9 @@ import json
 import logging
 import mimetypes
 import os
+import re
 from datetime import datetime, timezone
 from enum import Enum
-import re
 from typing import List, Union
 
 import boto3

--- a/planet/planet_adaptor/__main__.py
+++ b/planet/planet_adaptor/__main__.py
@@ -77,20 +77,20 @@ product_bundle_map = {
     },
 }
 
-
-def get_asset_details(file_path: str) -> tuple:
-    """
-    Returns a tuple (name, description) if a match is found, otherwise (file_base_name, "").
-    """
-    patterns = [
+regex_patterns = [
         (r"\/manifest\.json$", "manifest", "Manifest file"),
         (r"\/[^\\:?\"<>|]+_metadata\.json$", "metadata", "Metadata file"),
         (r"\/[^\\:?\"<>|]+_udm\d?+[^\\:?\"<>|]+\.tif$", "udm", "Usable data mask"),
         (r"\/[^\\:?\"<>|]+\.tif$", "primaryAsset", "GeoTIFF image file"),
     ]
 
+
+def get_asset_details(file_path: str) -> tuple:
+    """
+    Returns a tuple (name, description) if a match is found, otherwise (file_base_name, "").
+    """
     # Test the file path against each regex
-    for pattern, name, description in patterns:
+    for pattern, name, description in regex_patterns:
         if re.search(pattern, file_path.lower()):
             return name, description
 

--- a/planet/planet_adaptor/__main__.py
+++ b/planet/planet_adaptor/__main__.py
@@ -78,7 +78,6 @@ product_bundle_map = {
 }
 
 
-
 def get_asset_details(file_path: str) -> tuple:
     """
     Returns a tuple (name, description) if a match is found, otherwise (file_base_name, "").

--- a/planet/planet_adaptor/__main__.py
+++ b/planet/planet_adaptor/__main__.py
@@ -78,11 +78,11 @@ product_bundle_map = {
 }
 
 regex_patterns = [
-        (r"\/manifest\.json$", "manifest", "Manifest file"),
-        (r"\/[^\\:?\"<>|]+_metadata\.json$", "metadata", "Metadata file"),
-        (r"\/[^\\:?\"<>|]+_udm\d?+[^\\:?\"<>|]+\.tif$", "udm", "Usable data mask"),
-        (r"\/[^\\:?\"<>|]+\.tif$", "primaryAsset", "GeoTIFF image file"),
-    ]
+    (r"\/manifest\.json$", "manifest", "Manifest file"),
+    (r"\/[^\\:?\"<>|]+_metadata\.json$", "metadata", "Metadata file"),
+    (r"\/[^\\:?\"<>|]+_udm\d?+[^\\:?\"<>|]+\.tif$", "udm", "Usable data mask"),
+    (r"\/[^\\:?\"<>|]+\.tif$", "primaryAsset", "GeoTIFF image file"),
+]
 
 
 def get_asset_details(file_path: str) -> tuple:

--- a/planet/planet_adaptor/__main__.py
+++ b/planet/planet_adaptor/__main__.py
@@ -6,8 +6,8 @@ import json
 import logging
 import mimetypes
 import os
-from enum import Enum
 import re
+from enum import Enum
 from typing import List
 
 import boto3

--- a/planet/planet_adaptor/__main__.py
+++ b/planet/planet_adaptor/__main__.py
@@ -7,6 +7,7 @@ import logging
 import mimetypes
 import os
 from enum import Enum
+import re
 from typing import List
 
 import boto3
@@ -77,6 +78,27 @@ product_bundle_map = {
 }
 
 
+
+def get_asset_details(file_path: str) -> tuple:
+    """
+    Returns a tuple (name, description) if a match is found, otherwise (file_base_name, "").
+    """
+    patterns = [
+        (r"\/manifest\.json$", "manifest", "Manifest file"),
+        (r"\/[^\\:?\"<>|]+_metadata\.json$", "metadata", "Metadata file"),
+        (r"\/[^\\:?\"<>|]+_udm\d?+[^\\:?\"<>|]+\.tif$", "udm", "Usable data mask"),
+        (r"\/[^\\:?\"<>|]+\.tif$", "primaryAsset", "GeoTIFF image file"),
+    ]
+
+    # Test the file path against each regex
+    for pattern, name, description in patterns:
+        if re.search(pattern, file_path.lower()):
+            return name, description
+
+    # If no match is found, return file name and empty description
+    return os.path.basename(file_path), ""
+
+
 def update_stac_item_success(
     stac_item: dict,
     file_name: str,
@@ -88,10 +110,20 @@ def update_stac_item_success(
 ):
     """Update the STAC item with the assets and success order status"""
     # Add all files in the directory as assets to the STAC item
-    for root, _, files in os.walk(directory):
-        for asset in files:
+    name_counter = {}
+    for root, dirs, files in os.walk(directory):
+        dirs.sort()
+        for asset in sorted(files):
             asset_path = os.path.join(root, asset)
-            asset_name = os.path.basename(asset_path)
+            asset_name, description = get_asset_details(asset_path)
+
+            # Cannot have duplicate asset names
+            if asset_name in name_counter:
+                # Append an incrementing integer
+                name_counter[asset_name] += 1
+                asset_name = f"{asset_name}_{name_counter[asset_name]}"
+            else:
+                name_counter[asset_name] = 0
 
             # Determine the MIME type of the file
             mime_type, _ = mimetypes.guess_type(asset_path)
@@ -103,6 +135,8 @@ def update_stac_item_success(
                 "href": asset_path,
                 "type": mime_type,
             }
+            if description:
+                stac_item["assets"][asset_name]["title"] = description
     # Mark the order as succeeded and upload the updated STAC item
     update_stac_order_status(stac_item, order_name, OrderStatus.SUCCEEDED.value)
 


### PR DESCRIPTION
Main assets are guessed based on the filename.
asset names shouldn't duplicate, so an incrementing count is added if there are duplicates.
Airbus tifs can be tiled, so include row and column if so
Added regex for other files if there is sufficient documentation or info from previous runs.

Pending testing on prod/staging