### PR TITLE
EODHP-1280 Nested adaptor asset output file structure is flattened

### DIFF
--- a/airbus/airbus_optical_adaptor/__main__.py
+++ b/airbus/airbus_optical_adaptor/__main__.py
@@ -236,7 +236,7 @@ def main(
                 download_and_store_locally(
                     commercial_data_bucket,
                     obj,
-                    "assets",
+                    customer_reference,
                 )
         except Exception as e:
             reason = f"Failed to retrieve data: {e}"
@@ -256,7 +256,7 @@ def main(
             stac_item.file_name,
             stac_item.collection_id,
             order_id,
-            "assets",
+            customer_reference,
             workspace,
             workspace_bucket,
         )

--- a/airbus/airbus_sar_adaptor/__main__.py
+++ b/airbus/airbus_sar_adaptor/__main__.py
@@ -171,7 +171,7 @@ def main(
                 download_and_store_locally(
                     commercial_data_bucket,
                     obj,
-                    "assets",
+                    order_id,
                 )
         except Exception as e:
             reason = f"Failed to retrieve data: {e}"
@@ -191,7 +191,7 @@ def main(
             stac_item.file_name,
             stac_item.collection_id,
             order_id,
-            "assets",
+            order_id,
             workspace,
             workspace_bucket,
         )

--- a/planet/planet_adaptor/__main__.py
+++ b/planet/planet_adaptor/__main__.py
@@ -438,7 +438,7 @@ def main(
             )
 
             download_and_store_locally(
-                commercial_data_bucket, f"{delivery_folder}/{order_id}", "assets"
+                commercial_data_bucket, f"{delivery_folder}/{order_id}", order_id
             )
         except Exception as e:
             reason = f"Failed to retrieve data: {e}"
@@ -458,7 +458,7 @@ def main(
             stac_item.file_name,
             stac_item.collection_id,
             order_name,
-            "assets",
+            order_id,
             workspace,
             workspace_bucket,
         )


### PR DESCRIPTION
Assets are stored in a subfolder named per a unique identifier for the order.
When the assets are stored in s3, this folder and subfolder structure will be preserved (in a stageout PR). So this allows for ordered assets to be separated by a unique id per order.